### PR TITLE
Recover dropped citation-validation decisions and harden reply handling

### DIFF
--- a/osf_sync/dynamo/preprints_repo.py
+++ b/osf_sync/dynamo/preprints_repo.py
@@ -1489,12 +1489,15 @@ class PreprintsRepo:
         *decision* should be ``"approved"`` or ``"rejected"``.
         """
         now = dt.datetime.utcnow().isoformat()
+        # Require the reference to already exist so a stale/typo target raises
+        # ConditionalCheckFailedException instead of creating a sparse phantom item.
         self.t_refs.update_item(
             Key={"osf_id": osf_id, "ref_id": ref_id},
             UpdateExpression=(
                 "SET citation_validation_status=:s, "
                 "citation_validation_updated_at=:t, updated_at=:t"
             ),
+            ConditionExpression="attribute_exists(osf_id)",
             ExpressionAttributeValues={":s": decision, ":t": now},
         )
 
@@ -1525,9 +1528,12 @@ class PreprintsRepo:
                 "citation_validation_review_id"
             )
             eav = {":t": now}
+        # Require the preprint to exist so this never creates a sparse phantom item
+        # (e.g. from a decision applied to an orphan reference).
         self.t_preprints.update_item(
             Key={"osf_id": osf_id},
             UpdateExpression=expr,
+            ConditionExpression="attribute_exists(osf_id)",
             ExpressionAttributeValues=eav,
         )
 

--- a/osf_sync/email/citation_review.py
+++ b/osf_sync/email/citation_review.py
@@ -1,6 +1,7 @@
 """Send batch citation-distance review emails and build mailto: action links."""
 from __future__ import annotations
 
+import html
 import logging
 import os
 import urllib.parse
@@ -40,9 +41,10 @@ def _build_batch_html(all_flagged: Dict[str, List[Dict[str, Any]]], review_id: s
         for i, ref in enumerate(refs, 1):
             ref_id = ref.get("ref_id", "unknown")
             distance = ref.get("citation_distance", 0)
-            doi = ref.get("original_doi") or ref.get("doi", "")
-            raw = ref.get("raw_citation", "")
-            apa = ref.get("citation_apa_resolved", "")
+            # Escape externally-sourced fields so they cannot break or spoof the HTML.
+            doi = html.escape(str(ref.get("original_doi") or ref.get("doi", "")))
+            raw = html.escape(str(ref.get("raw_citation", "")))
+            apa = html.escape(str(ref.get("citation_apa_resolved", "")))
             target = f"{pid}/{ref_id}"
 
             lines.append(f"<h3>Reference {i}: {ref_id} — Distance: {distance:.1%}</h3>")
@@ -58,10 +60,17 @@ def _build_batch_html(all_flagged: Dict[str, List[Dict[str, Any]]], review_id: s
                          f'| <a href="{reject_link}">REJECT {target}</a></p>')
             lines.append("<hr>")
 
-    # Remainder actions at the bottom
-    approve_rem_link = _mailto_link(subject, f"APPROVE REMAINDER\n\nReview ID: {review_id}")
-    approve_rem_apa_link = _mailto_link(subject, f"APPROVE REMAINDER USE APA\n\nReview ID: {review_id}")
-    reject_rem_link = _mailto_link(subject, f"REJECT REMAINDER\n\nReview ID: {review_id}")
+    # Remainder actions at the bottom.  Embed the full member list as a "Targets:"
+    # line so the reply is self-contained: applying REMAINDER never depends on the
+    # server-side review_id link (which re-screening can clear before a reply arrives).
+    targets_line = "Targets: " + ", ".join(
+        f"{pid}/{ref.get('ref_id', 'unknown')}"
+        for pid, refs in all_flagged.items()
+        for ref in refs
+    )
+    approve_rem_link = _mailto_link(subject, f"APPROVE REMAINDER\n{targets_line}\n\nReview ID: {review_id}")
+    approve_rem_apa_link = _mailto_link(subject, f"APPROVE REMAINDER USE APA\n{targets_line}\n\nReview ID: {review_id}")
+    reject_rem_link = _mailto_link(subject, f"REJECT REMAINDER\n{targets_line}\n\nReview ID: {review_id}")
 
     lines.append("<p><b>Bulk actions</b> (apply to all refs not individually decided above):</p>")
     lines.append(f'<p><a href="{approve_rem_link}">APPROVE REMAINDER</a> — All DOI matches are correct; use raw citations</p>')
@@ -104,6 +113,17 @@ def _build_batch_plain(all_flagged: Dict[str, List[Dict[str, Any]]], review_id: 
             parts.append(f"Reply: APPROVE {target} / APPROVE {target} USE APA / REJECT {target}")
             parts.append("")
 
+    # Self-contained bulk action: the Targets line lets REMAINDER apply without the
+    # server-side review_id link.
+    targets_line = "Targets: " + ", ".join(
+        f"{pid}/{ref.get('ref_id', 'unknown')}"
+        for pid, refs in all_flagged.items()
+        for ref in refs
+    )
+    parts.append("Bulk action (all refs not individually decided):")
+    parts.append(f"  APPROVE REMAINDER / APPROVE REMAINDER USE APA / REJECT REMAINDER")
+    parts.append(f"  {targets_line}")
+    parts.append("")
     parts.append(f"Review ID: {review_id}")
     return "\n".join(parts)
 

--- a/osf_sync/email/inbox.py
+++ b/osf_sync/email/inbox.py
@@ -7,11 +7,14 @@ from __future__ import annotations
 
 import email
 import email.policy
+import html
 import imaplib
 import logging
 import os
 import re
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from botocore.exceptions import ClientError
 
 log = logging.getLogger(__name__)
 
@@ -256,6 +259,7 @@ def process_validation_responses(
     responses_processed = 0
     decisions_applied = 0
     errors = 0
+    batch_member_cache: Dict[str, List[Tuple[str, str]]] = {}
 
     try:
         imap = imaplib.IMAP4_SSL("imap.gmail.com", 993)
@@ -303,95 +307,177 @@ def process_validation_responses(
                         if part.get_content_type() == "text/html":
                             payload = part.get_payload(decode=True)
                             if payload:
-                                body = re.sub(r"<[^>]+>", " ", payload.decode("utf-8", errors="replace"))
+                                body = _html_to_text(payload.decode("utf-8", errors="replace"))
                                 break
                 if not body:
                     continue
 
-                review_id, decisions = _parse_validation_body(body)
+                # Parse only the reviewer's own (top-posted) text, never the quoted
+                # original review email — whose instructional lines would otherwise be
+                # misread as decisions.
+                reply_text = _top_posted_region(body)
+                review_id, decisions = _parse_validation_body(reply_text)
                 if not review_id or not decisions:
                     log.info("Skipping message — no review ID or decisions found")
                     continue
 
-                # Find all preprints associated with this batch review_id
+                # Preprints still linked to this batch via citation_validation_review_id.
+                # Re-screening can overwrite/clear that link before a reply arrives, so
+                # this scan is frequently empty.  Explicit per-ref targets carry
+                # osf_id/ref_id directly and are applied regardless; REMAINDER is scoped
+                # from the reply's own Targets list (or the outgoing review email).
                 affected_osf_ids = _get_preprints_for_batch_review(repo, review_id)
-                if not affected_osf_ids:
-                    log.warning("No preprints found for review_id %s", review_id)
-                    errors += 1
-                    continue
 
-                # Apply individual decisions first, track what's been decided
-                decided_pairs: set[tuple[str, str]] = set()
-                remainder_decision: Optional[tuple[str, bool]] = None
+                decided_pairs: Set[Tuple[str, str]] = set()
+                # Only preprints we actually write a decision to are "touched" and thus
+                # eligible to have their email gate released — never a stale target.
+                touched_osf_ids: Set[str] = set()
+                remainder_decision: Optional[Tuple[str, bool]] = None
+                applied_here = 0
+                resolved = False
+                had_failure = False  # transient write/read error → leave unread for retry
 
+                def _apply(osf_id: str, ref_id: str, decision: str, use_apa: bool) -> str:
+                    """Record one decision.
+
+                    Returns 'applied' on a real write, 'skipped' for a non-retryable
+                    no-op (unknown target), or 'failed' for a retryable error.  Only an
+                    'applied' result means the preprint should be treated as touched.
+                    """
+                    nonlocal decisions_applied, applied_here, errors
+                    if dry_run:
+                        decisions_applied += 1
+                        applied_here += 1
+                        return "applied"
+                    status_val = "approved" if decision == "approve" else "rejected"
+                    try:
+                        repo.update_reference_validation_decision(osf_id, ref_id, decision=status_val)
+                    except ClientError as exc:
+                        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                            # Target reference does not exist (stale/typo) — not retryable.
+                            log.warning("Skipping decision for unknown reference %s/%s", osf_id, ref_id)
+                            errors += 1
+                            return "skipped"
+                        log.warning("Failed to apply decision %s for %s/%s",
+                                    status_val, osf_id, ref_id, exc_info=True)
+                        errors += 1
+                        return "failed"
+                    except Exception:
+                        log.warning("Failed to apply decision %s for %s/%s",
+                                    status_val, osf_id, ref_id, exc_info=True)
+                        errors += 1
+                        return "failed"
+                    if use_apa and status_val == "approved":
+                        if not _replace_raw_with_apa(repo, osf_id, ref_id):
+                            return "failed"  # APA substitution failed — retry next run
+                    decisions_applied += 1
+                    applied_here += 1
+                    return "applied"
+
+                # 1) Explicit per-ref decisions ({osf_id}/{ref_id}) — applied directly,
+                #    independent of the (often broken) review_id link.
                 for decision, target, use_apa in decisions:
                     if target.upper() == "REMAINDER":
                         remainder_decision = (decision, use_apa)
-                    else:
-                        # target is {osf_id}/{ref_id}
-                        parts = target.split("/", 1)
-                        if len(parts) != 2:
-                            log.warning("Invalid target format: %s", target)
-                            errors += 1
-                            continue
-                        osf_id, ref_id = parts
-                        if not dry_run:
-                            status_val = "approved" if decision == "approve" else "rejected"
-                            try:
-                                repo.update_reference_validation_decision(
-                                    osf_id, ref_id, decision=status_val,
-                                )
-                                if use_apa and status_val == "approved":
-                                    _replace_raw_with_apa(repo, osf_id, ref_id)
-                                decisions_applied += 1
-                            except Exception:
-                                log.warning("Failed to apply decision %s for %s/%s",
-                                            status_val, osf_id, ref_id, exc_info=True)
-                                errors += 1
-                        else:
-                            decisions_applied += 1
-                        decided_pairs.add((osf_id, ref_id))
+                        continue
+                    parts = target.split("/", 1)
+                    if len(parts) != 2:
+                        log.warning("Invalid target format: %s", target)
+                        errors += 1
+                        continue
+                    osf_id, ref_id = parts
+                    outcome = _apply(osf_id, ref_id, decision, use_apa)
+                    if outcome == "applied":
+                        touched_osf_ids.add(osf_id)  # only real writes touch the preprint
+                    elif outcome == "failed":
+                        had_failure = True
+                    decided_pairs.add((osf_id, ref_id))
+                    resolved = True
 
-                # Apply REMAINDER to all undecided pending refs
+                # 2) REMAINDER — every batch ref not individually decided and still
+                #    pending_review.  Membership is taken from the reply's own Targets
+                #    list first, then the live review_id link, then the outgoing email.
                 if remainder_decision:
                     rem_decision, rem_use_apa = remainder_decision
-                    for osf_id in affected_osf_ids:
-                        pending_refs = _get_pending_refs(repo, osf_id)
-                        for ref_id in pending_refs:
-                            if (osf_id, ref_id) in decided_pairs:
-                                continue
-                            if not dry_run:
-                                status_val = "approved" if rem_decision == "approve" else "rejected"
-                                try:
-                                    repo.update_reference_validation_decision(
-                                        osf_id, ref_id, decision=status_val,
-                                    )
-                                    if rem_use_apa and status_val == "approved":
-                                        _replace_raw_with_apa(repo, osf_id, ref_id)
-                                    decisions_applied += 1
-                                except Exception:
-                                    log.warning("Failed to apply remainder decision %s for %s/%s",
-                                                status_val, osf_id, ref_id, exc_info=True)
-                                    errors += 1
-                            else:
-                                decisions_applied += 1
+                    embedded = _parse_remainder_targets(reply_text)
+                    if embedded:
+                        candidate_pairs: List[Tuple[str, str]] = embedded
+                        resolved = True
+                    elif affected_osf_ids:
+                        candidate_pairs = [
+                            (oid, rid)
+                            for oid in affected_osf_ids
+                            for rid in _get_pending_refs(repo, oid)
+                        ]
+                        resolved = True
+                    else:
+                        if review_id not in batch_member_cache:
+                            batch_member_cache[review_id] = list(
+                                _get_batch_members_from_outgoing(imap, review_id, sender)
+                            )
+                        candidate_pairs = list(batch_member_cache[review_id])
+                        if candidate_pairs:
+                            resolved = True
+                        else:
+                            log.warning("Could not determine batch membership for REMAINDER on %s",
+                                        review_id)
+                    for osf_id, ref_id in candidate_pairs:
+                        if (osf_id, ref_id) in decided_pairs:
+                            continue
+                        pending = _ref_is_pending(repo, osf_id, ref_id)
+                        if pending is None:  # read failure — retry later
+                            had_failure = True
+                            continue
+                        if not pending:  # decided elsewhere or never pending
+                            continue
+                        outcome = _apply(osf_id, ref_id, rem_decision, rem_use_apa)
+                        if outcome == "applied":
+                            touched_osf_ids.add(osf_id)
+                        elif outcome == "failed":
+                            had_failure = True
+                        decided_pairs.add((osf_id, ref_id))
 
-                # Clear pending flags on all affected preprints
-                if not dry_run:
-                    for osf_id in affected_osf_ids:
+                if not resolved:
+                    # Nothing matched (e.g. a REMAINDER-only reply whose outgoing review
+                    # email is no longer available).  Leave unread so a later run can retry.
+                    log.warning("No preprints or batch members found for review_id %s", review_id)
+                    errors += 1
+                    continue
+
+                # Release the preprint-level email gate only once no references remain
+                # pending_review — a partial reply must not unlock a preprint that still
+                # has unreviewed high-distance citations.  A consistent read ensures the
+                # just-written decisions are visible; a failure here leaves the message
+                # unread so the gate is retried rather than stranded.
+                if not dry_run and not had_failure:
+                    for osf_id in touched_osf_ids:
                         try:
-                            repo.set_citation_validation_pending(osf_id, pending=False)
+                            if not _get_pending_refs(repo, osf_id, consistent=True):
+                                repo.set_citation_validation_pending(osf_id, pending=False)
+                        except ClientError as exc:
+                            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                                # Preprint row does not exist (orphan ref) — nothing to
+                                # clear and not retryable; do not create a phantom item.
+                                log.warning("Preprint %s missing; skipping gate clear", osf_id)
+                                continue
+                            log.warning("Failed to clear pending flag for %s", osf_id, exc_info=True)
+                            errors += 1
+                            had_failure = True
                         except Exception:
                             log.warning("Failed to clear pending flag for %s", osf_id, exc_info=True)
                             errors += 1
+                            had_failure = True
 
                 responses_processed += 1
                 log.info("Processed batch validation response",
                          extra={"review_id": review_id,
-                                "affected_preprints": len(affected_osf_ids),
-                                "decisions": decisions_applied})
+                                "affected_preprints": len(touched_osf_ids),
+                                "decisions_applied": applied_here,
+                                "had_failure": had_failure})
 
-                if not dry_run:
+                # Only mark read when every intended write succeeded; otherwise leave
+                # the reply unread so the next run retries it.
+                if not dry_run and not had_failure:
                     imap.store(msg_id, "+FLAGS", "\\Seen")
 
             except Exception:
@@ -412,8 +498,12 @@ def process_validation_responses(
     }
 
 
-def _replace_raw_with_apa(repo, osf_id: str, ref_id: str) -> None:
-    """Overwrite raw_citation with citation_apa_resolved so the author email uses the clean APA version."""
+def _replace_raw_with_apa(repo, osf_id: str, ref_id: str) -> bool:
+    """Overwrite raw_citation with citation_apa_resolved for the author email.
+
+    Returns False only on an actual read/write error (so the caller can retry);
+    a missing APA citation is a no-op success.
+    """
     import datetime as dt
     try:
         item = repo.t_refs.get_item(
@@ -423,7 +513,7 @@ def _replace_raw_with_apa(repo, osf_id: str, ref_id: str) -> None:
         apa = (item or {}).get("citation_apa_resolved")
         if not apa:
             log.info("No APA citation to substitute for %s/%s", osf_id, ref_id)
-            return
+            return True
         now = dt.datetime.utcnow().isoformat()
         repo.t_refs.update_item(
             Key={"osf_id": osf_id, "ref_id": ref_id},
@@ -431,8 +521,10 @@ def _replace_raw_with_apa(repo, osf_id: str, ref_id: str) -> None:
             ExpressionAttributeValues={":apa": apa, ":src": "apa_override", ":t": now},
         )
         log.info("Replaced raw_citation with APA for %s/%s", osf_id, ref_id)
+        return True
     except Exception:
         log.warning("Failed to replace raw_citation with APA for %s/%s", osf_id, ref_id, exc_info=True)
+        return False
 
 
 def _get_preprints_for_batch_review(repo, review_id: str) -> list[str]:
@@ -458,8 +550,12 @@ def _get_preprints_for_batch_review(repo, review_id: str) -> list[str]:
     return osf_ids
 
 
-def _get_pending_refs(repo, osf_id: str) -> list[str]:
-    """Return ref_ids with citation_validation_status == 'pending_review' for a preprint."""
+def _get_pending_refs(repo, osf_id: str, consistent: bool = False) -> list[str]:
+    """Return ref_ids with citation_validation_status == 'pending_review' for a preprint.
+
+    Pass consistent=True for a strongly consistent read (used right after writing
+    decisions, so the email-gate clear sees the just-written statuses).
+    """
     ref_ids = []
     last_key = None
     while True:
@@ -467,6 +563,7 @@ def _get_pending_refs(repo, osf_id: str) -> list[str]:
             "KeyConditionExpression": "osf_id = :oid",
             "FilterExpression": "citation_validation_status = :s",
             "ExpressionAttributeValues": {":oid": osf_id, ":s": "pending_review"},
+            "ConsistentRead": consistent,
         }
         if last_key:
             kwargs["ExclusiveStartKey"] = last_key
@@ -479,3 +576,117 @@ def _get_pending_refs(repo, osf_id: str) -> list[str]:
         if not last_key:
             break
     return ref_ids
+
+
+def _ref_is_pending(repo, osf_id: str, ref_id: str) -> Optional[bool]:
+    """Whether the reference still has citation_validation_status == 'pending_review'.
+
+    Returns None on a read error so callers can distinguish "not pending" from
+    "could not determine" and avoid silently dropping a decision.
+    """
+    try:
+        item = repo.t_refs.get_item(
+            Key={"osf_id": osf_id, "ref_id": ref_id},
+            ProjectionExpression="citation_validation_status",
+        ).get("Item")
+    except Exception:
+        log.warning("Failed to read status for %s/%s", osf_id, ref_id, exc_info=True)
+        return None
+    return bool(item) and item.get("citation_validation_status") == "pending_review"
+
+
+_QUOTE_MARKERS = (
+    re.compile(r"^\s*>"),
+    re.compile(r"^\s*On\b.+\bwrote:\s*$", re.IGNORECASE),
+    re.compile(r"^\s*-{2,}\s*Original Message\s*-{2,}", re.IGNORECASE),
+    re.compile(r"^\s*From:\s", re.IGNORECASE),
+    re.compile(r"^\s*_{5,}\s*$"),
+    re.compile(r"^\s*Sent from\b", re.IGNORECASE),
+)
+
+
+def _html_to_text(html_body: str) -> str:
+    """Flatten an HTML reply to text while preserving line structure.
+
+    Quoted-reply containers are dropped first so the original review email's
+    instructional lines cannot be parsed as decisions, and block boundaries become
+    newlines so _top_posted_region's line-based quote markers still apply.
+    """
+    html_body = re.split(r"<blockquote|<div[^>]*gmail_quote", html_body, maxsplit=1, flags=re.IGNORECASE)[0]
+    html_body = re.sub(r"(?i)<\s*br\s*/?>", "\n", html_body)
+    html_body = re.sub(r"(?i)</\s*(p|div|tr|li|h[1-6]|blockquote)\s*>", "\n", html_body)
+    return html.unescape(re.sub(r"<[^>]+>", " ", html_body))
+
+
+def _top_posted_region(body: str) -> str:
+    """Return the reviewer's own text, dropping any quoted original/signature.
+
+    Reviewers top-post their decision above the quoted review email; parsing the
+    whole body would re-read the original's instructional lines (e.g. the
+    'APPROVE REMAINDER' action text) as if they were decisions.
+    """
+    kept: list[str] = []
+    for line in body.splitlines():
+        if any(p.match(line) for p in _QUOTE_MARKERS):
+            break
+        kept.append(line)
+    return "\n".join(kept)
+
+
+# Matches an explicit "{osf_id}/{ref_id}" target embedded in review text.
+_TARGET_PAIR_RE = re.compile(r"\b([A-Za-z0-9]+(?:_v\d+)?)/([A-Za-z0-9_]+)\b")
+
+
+def _parse_remainder_targets(body: str) -> list[tuple[str, str]]:
+    """Extract the batch member list a self-contained REMAINDER reply carries.
+
+    Newer review emails embed a ``Targets: a/b, c/d`` line in the REMAINDER action so
+    the reply no longer depends on the server-side review_id link.  Returns an empty
+    list for older replies that lack the line.
+    """
+    pairs: list[tuple[str, str]] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith("targets:"):
+            for m in _TARGET_PAIR_RE.finditer(stripped[len("targets:"):]):
+                pairs.append((m.group(1), m.group(2)))
+    return pairs
+
+
+def _get_batch_members_from_outgoing(imap, review_id: str, sender: str) -> set[tuple[str, str]]:
+    """Reconstruct a batch's (osf_id, ref_id) members from its outgoing review email.
+
+    Used as a fallback for older REMAINDER replies that pre-date the embedded
+    ``Targets:`` line and whose review_id link has since been cleared.  The original
+    outgoing email (still in the label) lists every flagged reference.
+    """
+    members: set[tuple[str, str]] = set()
+    try:
+        status, data = imap.search(None, 'BODY "%s"' % review_id)
+        if status != "OK" or not data or not data[0]:
+            return members
+        for mid in data[0].split():
+            msg = _fetch_message(imap, mid)
+            if msg is None:
+                continue
+            if sender.lower() not in msg.get("From", "").lower():
+                continue  # only the outgoing review email enumerates all members
+            body = ""
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain":
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        body = payload.decode("utf-8", errors="replace")
+                        break
+            if not body or review_id not in body:
+                continue
+            for m in re.finditer(
+                r"(?:APPROVE|REJECT)\s+([A-Za-z0-9]+(?:_v\d+)?)/([A-Za-z0-9_]+)",
+                body, re.IGNORECASE,
+            ):
+                members.add((m.group(1), m.group(2)))
+            if members:
+                break
+    except Exception:
+        log.warning("Failed to reconstruct batch members for %s", review_id, exc_info=True)
+    return members

--- a/tests/test_inbox_processing.py
+++ b/tests/test_inbox_processing.py
@@ -7,9 +7,36 @@ from unittest.mock import MagicMock, Mock, patch
 from osf_sync.email.inbox import (
     _extract_bounce_addresses,
     _extract_unsub_sender,
+    _parse_remainder_targets,
+    _html_to_text,
     _parse_validation_body,
+    _top_posted_region,
     process_inbox,
+    process_validation_responses,
 )
+from osf_sync.email.citation_review import _build_batch_html, _build_batch_plain
+from botocore.exceptions import ClientError
+
+
+def _make_validation_reply(body: str, sender: str = "reviewer@bbk.ac.uk") -> bytes:
+    raw = (
+        f"From: Reviewer <{sender}>\r\n"
+        "To: flora@replications.forrt.org\r\n"
+        "Subject: Re: Citation Distance Review — Batch\r\n"
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        f"{body}\r\n"
+    )
+    return raw.encode("utf-8")
+
+
+def _validation_imap(reply_bytes: bytes):
+    """A MagicMock IMAP returning a single unseen validation reply (seq b'1')."""
+    imap = MagicMock()
+    imap.select.return_value = ("OK", [b"1"])
+    imap.search.return_value = ("OK", [b"1"])
+    imap.fetch.return_value = ("OK", [(b"1", reply_bytes)])
+    return imap
 
 
 def _make_bounce_dsn(recipient: str = "user@example.com") -> email.message.Message:
@@ -275,6 +302,166 @@ class TestParseValidationBody(unittest.TestCase):
         review_id, decisions = _parse_validation_body(body)
         self.assertIsNone(review_id)
         self.assertEqual(len(decisions), 1)
+
+
+class TestValidationResponseFailureHandling(unittest.TestCase):
+    """Regression tests for the failure/edge paths of process_validation_responses."""
+
+    def _repo(self):
+        repo = Mock()
+        repo.t_preprints.scan.return_value = {"Items": []}  # no review_id link
+        return repo
+
+    @patch("osf_sync.email.inbox._sender_address", return_value="flora@replications.forrt.org")
+    @patch("osf_sync.email.inbox.imaplib.IMAP4_SSL")
+    @patch("osf_sync.dynamo.preprints_repo.PreprintsRepo")
+    @patch.dict("os.environ", {"GMAIL_APP_PASSWORD": "fake-pw"})
+    def test_stale_target_does_not_create_phantom_preprint(self, mock_repo_cls, mock_imap_cls, _s) -> None:
+        repo = self._repo()
+        # The reference no longer exists → conditional update fails.
+        repo.update_reference_validation_decision.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException"}}, "UpdateItem"
+        )
+        mock_repo_cls.return_value = repo
+        imap = _validation_imap(_make_validation_reply(
+            "APPROVE gone_v1/b99\nReview ID: review-batch-stale\n"
+        ))
+        mock_imap_cls.return_value = imap
+
+        result = process_validation_responses(max_messages=10)
+
+        # Must NOT touch the (non-existent) preprint — no sparse phantom item.
+        repo.set_citation_validation_pending.assert_not_called()
+        self.assertGreaterEqual(result["errors"], 1)
+        # Non-retryable: the message is acknowledged so it is not retried forever.
+        imap.store.assert_any_call(b"1", "+FLAGS", "\\Seen")
+
+    @patch("osf_sync.email.inbox._sender_address", return_value="flora@replications.forrt.org")
+    @patch("osf_sync.email.inbox.imaplib.IMAP4_SSL")
+    @patch("osf_sync.dynamo.preprints_repo.PreprintsRepo")
+    @patch.dict("os.environ", {"GMAIL_APP_PASSWORD": "fake-pw"})
+    def test_retryable_write_failure_leaves_message_unread(self, mock_repo_cls, mock_imap_cls, _s) -> None:
+        repo = self._repo()
+        repo.update_reference_validation_decision.side_effect = RuntimeError("dynamo down")
+        mock_repo_cls.return_value = repo
+        imap = _validation_imap(_make_validation_reply(
+            "APPROVE qnmja_v1/b33\nReview ID: review-batch-xyz\n"
+        ))
+        mock_imap_cls.return_value = imap
+
+        process_validation_responses(max_messages=10)
+
+        # Retryable failure → not acknowledged, gate not cleared.
+        repo.set_citation_validation_pending.assert_not_called()
+        for call in imap.store.call_args_list:
+            self.assertNotIn("\\Seen", call.args)
+
+    @patch("osf_sync.email.inbox._sender_address", return_value="flora@replications.forrt.org")
+    @patch("osf_sync.email.inbox.imaplib.IMAP4_SSL")
+    @patch("osf_sync.dynamo.preprints_repo.PreprintsRepo")
+    @patch.dict("os.environ", {"GMAIL_APP_PASSWORD": "fake-pw"})
+    def test_explicit_decision_applied_and_gate_cleared(self, mock_repo_cls, mock_imap_cls, _s) -> None:
+        repo = self._repo()
+        # After the decision, no refs remain pending_review → gate is released.
+        repo.t_refs.query.return_value = {"Items": []}
+        mock_repo_cls.return_value = repo
+        imap = _validation_imap(_make_validation_reply(
+            "APPROVE qnmja_v1/b33\nReview ID: review-batch-xyz\n"
+        ))
+        mock_imap_cls.return_value = imap
+
+        result = process_validation_responses(max_messages=10)
+
+        repo.update_reference_validation_decision.assert_called_once_with(
+            "qnmja_v1", "b33", decision="approved"
+        )
+        repo.set_citation_validation_pending.assert_called_once_with("qnmja_v1", pending=False)
+        self.assertEqual(result["responses_processed"], 1)
+        imap.store.assert_any_call(b"1", "+FLAGS", "\\Seen")
+
+
+class TestParseRemainderTargets(unittest.TestCase):
+    def test_extracts_targets_line(self) -> None:
+        body = (
+            "APPROVE REMAINDER USE APA\n"
+            "Targets: qnmja_v1/b33, yc6wn_v1/b9, ry85k_v2/b22\n\n"
+            "Review ID: review-batch-d4476529\n"
+        )
+        self.assertEqual(
+            _parse_remainder_targets(body),
+            [("qnmja_v1", "b33"), ("yc6wn_v1", "b9"), ("ry85k_v2", "b22")],
+        )
+
+    def test_absent_targets_returns_empty(self) -> None:
+        body = "APPROVE REMAINDER\n\nReview ID: review-batch-abcd1234\n"
+        self.assertEqual(_parse_remainder_targets(body), [])
+
+
+class TestTopPostedRegion(unittest.TestCase):
+    def test_keeps_decision_drops_signature(self) -> None:
+        body = (
+            "APPROVE qnmja_v1/b33\n"
+            "Review ID: review-batch-d4476529\n"
+            "Sent from Outlook for Android\n"
+        )
+        top = _top_posted_region(body)
+        review_id, decisions = _parse_validation_body(top)
+        self.assertEqual(review_id, "review-batch-d4476529")
+        self.assertEqual(decisions, [("approve", "qnmja_v1/b33", False)])
+
+    def test_ignores_quoted_original_bulk_actions(self) -> None:
+        # A manual reply that quotes the original review email must not pick up
+        # the quoted "REJECT REMAINDER" instruction line.
+        body = (
+            "APPROVE qnmja_v1/b33\n"
+            "Review ID: review-batch-d4476529\n"
+            "On Mon, 29 Jun 2026, FLoRA wrote:\n"
+            "> APPROVE REMAINDER / APPROVE REMAINDER USE APA / REJECT REMAINDER\n"
+            "> Targets: zzz_v1/b1\n"
+        )
+        top = _top_posted_region(body)
+        _, decisions = _parse_validation_body(top)
+        self.assertEqual(decisions, [("approve", "qnmja_v1/b33", False)])
+        self.assertEqual(_parse_remainder_targets(top), [])
+
+
+class TestHtmlToText(unittest.TestCase):
+    def test_drops_quoted_container_and_keeps_decision(self) -> None:
+        html = (
+            "<div>APPROVE qnmja_v1/b33<br>Review ID: review-batch-d4476529</div>"
+            '<blockquote class="gmail_quote">'
+            "<p>REJECT REMAINDER</p><p>Targets: zzz_v1/b1</p></blockquote>"
+        )
+        text = _html_to_text(html)
+        top = _top_posted_region(text)
+        _, decisions = _parse_validation_body(top)
+        self.assertEqual(decisions, [("approve", "qnmja_v1/b33", False)])
+        self.assertNotIn("REJECT", top)
+
+
+class TestBatchTemplateSelfContained(unittest.TestCase):
+    """The REMAINDER action must carry its own member list so replies do not
+    depend on the server-side review_id link."""
+
+    flagged = {
+        "qnmja_v1": [{"ref_id": "b33", "citation_distance": 0.4}],
+        "28g3z_v2": [{"ref_id": "b61", "citation_distance": 0.5}],
+    }
+
+    def test_plain_targets_roundtrip(self) -> None:
+        body = _build_batch_plain(self.flagged, "review-batch-d4476529")
+        self.assertIn("Targets: qnmja_v1/b33, 28g3z_v2/b61", body)
+        # The embedded Targets line round-trips back through the reply parser.
+        self.assertEqual(
+            _parse_remainder_targets(body),
+            [("qnmja_v1", "b33"), ("28g3z_v2", "b61")],
+        )
+
+    def test_html_includes_targets_in_remainder_links(self) -> None:
+        html = _build_batch_html(self.flagged, "review-batch-d4476529")
+        # Targets appear URL-encoded inside the mailto bodies (commas/slashes escaped).
+        self.assertIn("qnmja_v1", html)
+        self.assertIn("Targets", html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recovers citation-validation decisions that were being silently dropped and hardens the reply handler.

Reviewer replies were matched to a batch via the preprint-level `citation_validation_review_id`. FLORA re-screening mints a fresh review_id and overwrites that link whenever it re-flags a still-pending citation, so by the time a reply arrived the link was usually gone and the handler bailed (`if not affected_osf_ids: errors += 1; continue`), dropping the decision. 69 references were stranded in `pending_review` across several months.

Now `process_validation_responses`:
- applies explicit `{osf_id}/{ref_id}` decisions directly, independent of the link;
- scopes REMAINDER from the reply's own embedded `Targets:` list, then the live link, then the original outgoing review email;
- parses only the reviewer's top-posted text (quoted plain-text and HTML quote blocks stripped);
- reports each write as applied/skipped/failed, leaves a reply unread on any retryable failure instead of losing the decision, and treats an unknown target as a non-retryable skip;
- only treats a preprint as touched after a real write, and releases its email gate only once a strongly consistent read shows no `pending_review` refs remain.

`citation_review.py` embeds a `Targets:` line in the REMAINDER actions so future replies are self-contained, and HTML-escapes displayed fields. `update_reference_validation_decision` / `set_citation_validation_pending` now require the target row to exist (ConditionExpression) so a stale/typo/orphan target can't create a phantom item.

Reviewed across five adversarial codex passes to convergence. Backlog of 69 stranded decisions drained in production (122 approved / 9 rejected, 0 pending). Suite green (175 tests, incl. new handler failure-path coverage).

Related: #70 (registration deviation recorded separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
